### PR TITLE
Remove cached file and add missed class on config

### DIFF
--- a/.phpunit.result.cache
+++ b/.phpunit.result.cache
@@ -1,1 +1,0 @@
-C:37:"PHPUnit\Runner\DefaultTestResultCache":44:{a:2:{s:7:"defects";a:0:{}s:5:"times";a:0:{}}}

--- a/config/config.php
+++ b/config/config.php
@@ -15,6 +15,7 @@ $cacheConfig = [
 ];
 
 $aggregator = new ConfigAggregator([
+    \Laminas\Diactoros\ConfigProvider::class,
     \WShafer\PSR11MonoLog\ConfigProvider::class,
     \Antidot\Logger\Container\Config\ConfigProvider::class,
     \Antidot\Container\Config\ConfigProvider::class,


### PR DESCRIPTION
# Changed log

- Removing cached file.
- Adding `\Laminas\Diactoros\ConfigProvider` class because it's included when running `composer install` command.