### PR TITLE
Add Composer plugin dependnecies to allow_plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,12 @@
     "test": "phpunit --colors=always"
   },
   "config": {
-    "sort-packages": true
+    "sort-packages": true,
+    "allow-plugins": {
+      "laminas/laminas-component-installer": true,
+      "phpro/grumphp": true,
+      "symfony/runtime": true
+    }
   },
   "extra": {
     "laminas": {


### PR DESCRIPTION
# Changed log

- Adding these dependencies to the `allow_plugin` setting. It can avoid exception message when running the `composer update` command:

```
  symfony/runtime contains a Composer plugin which is blo  
  cked by your allow-plugins config. You may add it to the list if you consid  
  er it safe.                                                                  
  You can run "composer config --no-plugins allow-plugins.laminas/laminas-com  
  ponent-installer [true|false]" to enable it (true) or disable it explicitly  
   and suppress this exception (false)                                         
  See https://getcomposer.org/allow-plugins
```

```
  laminas/laminas-component-installer contains a Composer plugin which is blo  
  cked by your allow-plugins config. You may add it to the list if you consid  
  er it safe.                                                                  
  You can run "composer config --no-plugins allow-plugins.laminas/laminas-com  
  ponent-installer [true|false]" to enable it (true) or disable it explicitly  
   and suppress this exception (false)                                         
  See https://getcomposer.org/allow-plugins
```

```
   phpro/grumphp contains a Composer plugin which is blo  
  cked by your allow-plugins config. You may add it to the list if you consid  
  er it safe.                                                                  
  You can run "composer config --no-plugins allow-plugins.laminas/laminas-com  
  ponent-installer [true|false]" to enable it (true) or disable it explicitly  
   and suppress this exception (false)                                         
  See https://getcomposer.org/allow-plugins
```